### PR TITLE
Fix error deploy system apps in development namespace

### DIFF
--- a/src/valve-core/toolbox/install
+++ b/src/valve-core/toolbox/install
@@ -509,7 +509,7 @@ __helm_init() {
     fi
 
     # namespace
-    NAMESPACE="${NAMESPACE:-kube-system}"
+    NAMESPACE="kube-system"
 
     __helm_install "${NAMESPACE}" "nginx-ingress"
     __helm_install "${NAMESPACE}" "docker-registry"


### PR DESCRIPTION
common.sh 에 NAMESPACE를 development로 통일하면서
toolbox 에서 install시 system app들 또한 development namespace에 설치하려고 하는 에러를 수정합니다.