### PR TITLE
Fix first install config error

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -2,6 +2,7 @@
 
 SHELL_DIR=$(dirname $0)
 CONFIG=${HOME}/.valve/valve-ctl
+mkdir ${HOME}/.valve
 touch ${CONFIG} && . ${CONFIG}
 # SHELL_DIR=${0}
 # MYNAME=${0##*/}

--- a/src/common.sh
+++ b/src/common.sh
@@ -3,7 +3,7 @@
 SHELL_DIR=$(dirname $0)
 CONFIG=${HOME}/.valve/valve-ctl
 CONFIG_DIR=${HOME}/.valve
-mkdir $CONFIG_DIR
+mkdir -p $CONFIG_DIR
 touch ${CONFIG} && . ${CONFIG}
 # SHELL_DIR=${0}
 # MYNAME=${0##*/}

--- a/src/common.sh
+++ b/src/common.sh
@@ -2,7 +2,7 @@
 
 SHELL_DIR=$(dirname $0)
 CONFIG=${HOME}/.valve/valve-ctl
-CONFIG_DIR=${HOME/.valve
+CONFIG_DIR=${HOME}/.valve
 mkdir $CONFIG_DIR
 touch ${CONFIG} && . ${CONFIG}
 # SHELL_DIR=${0}

--- a/src/common.sh
+++ b/src/common.sh
@@ -2,7 +2,8 @@
 
 SHELL_DIR=$(dirname $0)
 CONFIG=${HOME}/.valve/valve-ctl
-mkdir ${HOME}/.valve
+CONFIG_DIR=${HOME/.valve
+mkdir $CONFIG_DIR
 touch ${CONFIG} && . ${CONFIG}
 # SHELL_DIR=${0}
 # MYNAME=${0##*/}


### PR DESCRIPTION
처음 toolbox 부터 설치 시 .valve 디렉토리가 없어 에러 발생
이를 해결합니다.