### PR TITLE
Modify valvesecret

### DIFF
--- a/src/valve-core/_template/on
+++ b/src/valve-core/_template/on
@@ -238,21 +238,11 @@ type: Opaque
 data:
 EOF
 
-    LIST=$(cat .valvesecret)
+    LIST=$(cat .valvesecret)        ## .valvesecret should like this.. ex) AWS_SECRET=example
     for VAL in ${LIST}; do
-        _read "secret ${VAL} : "
-
-        if [ "${ANSWER}" != "" ]; then
-            echo -n ${ANSWER} | base64 > ${TMP}
-
-            CNT=$(cat ${TMP} | wc -l | xargs)
-            if [ "x${CNT}" == "x1" ]; then
-                echo "  ${VAL}: $(cat ${TMP})" >> ${TARGET}
-            else
-                echo "  ${VAL}: |-" >> ${TARGET}
-                sed "s/^/    /" ${TMP} >> ${TARGET}
-            fi
-        fi
+        VAL_KEY=$(echo ${VAL} | awk -F'=' '{print $1}')
+        VAL_SECRET=$(echo ${VAL} | awk -F'=' '{print $2}' | base64)
+        echo "  ${VAL_KEY}: ${VAL_SECRET}" >> ${TARGET}
     done
 
     # apply secret


### PR DESCRIPTION
.valvesecret을 kubernetes secret으로 만들 때 불필요하게 입력값을 받도록 되어있으며, 불필요한 조건문이 있어 이를 제거

단 .valvesecret을 작성할 때, SECRET=example 과 같이 "=" 을 붙여서 작성하도록 가이드를 해야할 것 같습니다.
또한 개발자들의 코드를 commit 할 때, .valvesecret은 commit 하지 않도록 가이드를 해야합니다.