### PR TITLE
Feature template fetch remotetemplate

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -130,8 +130,10 @@ _config_save() {
         echo "CHARTMUSEUM=${CHARTMUSEUM:-chartmuseum-devops.coruscant.opsnow.com}" >> ${CONFIG}
         echo "USERNAME=${USERNAME}" >> ${CONFIG}
     else
-        _success "CONFIG Set"
+        _result "CONFIG Set"
     fi
+    LIST=$CONFIG_DIR/${THIS_NAME}-draft-ls
+    curl -sL https://github.com/${THIS_REPO}/${THIS_NAME}/releases/download/${THIS_VERSION}/draft.tar.gz | tar zt | awk -F'/' '{print $1}' | sort -u > ${LIST}
 }
 
 _debug_mode() {

--- a/src/common.sh
+++ b/src/common.sh
@@ -61,6 +61,11 @@ _success() {
     exit 0
 }
 
+_warning() {
+    echo
+    _echo "- $@" 1
+}
+
 _error() {
     echo
     _echo "- $@" 1

--- a/src/valve-core/_template/fetch
+++ b/src/valve-core/_template/fetch
@@ -20,6 +20,8 @@ Params:
     -h, --help                                  valve fetch 화면을 보여줍니다.
 
     -n, --name string           (requirement)   템플릿을 설치합니다. 템플릿 리스트는 다음과 같으며, 다음 리스트에서 템플릿를 선택해야 합니다.
+                                                [custom]으로 되어있는 템플릿은 개발자가 등록한 템플릿입니다. 사용하실 때는 [custom]을 빼고 
+                                                valve fetch를 이용합니다.
                                                 ===== 템플릿 리스트 ====
 EOF
 LIST=/tmp/${THIS_NAME}-draft-ls
@@ -123,7 +125,7 @@ _run() {
 
 ##################################################################################
 _fetch(){
-    _result "draft package version: ${THIS_VERSION}"
+    _result "valve-ctl version: ${THIS_VERSION}"
 
     DIST=/tmp/${THIS_NAME}-draft-${THIS_VERSION}
     LIST=/tmp/${THIS_NAME}-draft-ls
@@ -160,9 +162,10 @@ __validate() {      # validate overwrite option
             if [ ! -d .valve-history ]; then
                 mkdir -p .valve-history
             fi
-            cp -r charts/ .valve-history/
+            if [ -d charts ]; then
+                cp -r charts/ .valve-history/
+            fi
             cp -r Dockerfile .valve-history
-            cp -r draft.toml .valve-history
             cp -r Jenkinsfile .valve-history
             rm -rf charts/ Dockerfile draft.toml Jenkinsfile
         fi
@@ -197,28 +200,95 @@ __pkg_version_check() {
             curl -sL https://github.com/${THIS_REPO}/${THIS_NAME}/releases/download/${THIS_VERSION}/draft.tar.gz | tar xz
             popd
 
-            _result "draft package downloaded."
+            _result "Template downloaded."
         fi
     fi
 }
 
 __pkg_name_check() {
     _debug_mode
+
     ls ${DIST} | sort > ${LIST}     # create LIST
     IDX=0
+    __template_count_validate
+
     CNT=`wc -l < ${LIST}`
+    
+    CONFIG_NAME_LIST=$(cat ${CONFIG} | sed '1,/REPO/d' | awk -F ' ' '{print $2}')
+    
+    if [ ${IDX} == ${CNT} ]; then       # Check name if doesn't match.
+        _result "Template: "${PARAM_NAME}
+
+        __config_count_validate
+        if [ "${CONFIG_RESULT}" == "" ]; then
+            pushd ${DIST} > /dev/null
+            if [ ! -d ${TEMPLATE} ]; then
+                git clone ${TEMPLATE_URL} ${TEMPLATE}
+                ls ${DIST} | sed 's/'${TEMPLATE}'/\[custom\]'${REMOTE_NAME}'\/'${REMOTE_TEMPLATE}'/g' | sort > ${LIST}
+            fi
+            popd > /dev/null
+            PACKAGE=${TEMPLATE}
+        elif [ ${CONFIG_RESULT} == "ERROR" ]; then
+            rm -rf ${DIST}
+            _error "\e[4m${PARAM_NAME}\e[0m template doesn't matching anything. So use 'valve repo list' and check it out!"
+        fi
+    else        # Check name correct one.
+        PACKAGE=${PARAM_NAME}
+    fi
+}
+
+__template_count_validate() {
+    _debug_mode
+
     while read VAL; do
         if ! [[ ${PARAM_NAME} =~ $VAL ]]; then
             IDX=$((IDX+1))
         fi
     done < ${LIST}
+}
 
-    if [ $IDX == $CNT ]; then       # Check name if doesn't match.
-        _result "Draft package: "${PARAM_NAME}
-        rm -rf ${DIST}
-        _error "Use valve fetch -h / valve fetch --help \n\e[4m${PARAM_NAME}\e[0m draft package doesn't matching anything"
-    else        # Check name
-        PACKAGE=${PARAM_NAME}
+__config_count_validate() {
+    _debug_mode
+
+    IDX_CF=0
+    _is_param_name=$(echo ${PARAM_NAME} | grep '/')
+    if [ "${_is_param_name}" == "" ]; then
+        _error "Use valve fetch -h / valve fetch --help \n\e[4m${PARAM_NAME}\e[0m template doesn't matching anything"
+    else
+        ## Parsing Input remote template
+        REMOTE_NAME=$(echo ${PARAM_NAME} | awk -F'/' '{print $1}')
+        REMOTE_TEMPLATE=$(echo ${PARAM_NAME} | awk -F'/' '{print $2}')
+    fi
+    
+    _config_tm_list=/tmp/_config_tm_list
+    cat ${CONFIG} | sed '1,/REPO/d' | awk -F' ' '{print $2"|"$3}' >> ${_config_tm_list}
+
+    IFS='|'
+    while read -r _name _u
+    do
+        if [ "$_name" == "${REMOTE_NAME}" ]; then
+            _protocol="$(echo ${_u} | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+            _url=$(echo ${_u} | sed -e s,$_protocol,,g)
+            _path=$(echo ${_url} | awk -F'.' '{print $(NF-1)}' | awk -F'/' '{print $NF}')
+            if [ "$_path" == "${REMOTE_TEMPLATE}" ]; then
+                if [ "${_protocol}" == "https://" ]; then
+                    TEMPLATE_URL=$_u
+                fi
+                IDX_CF=$((IDX_CF+1))
+            fi
+        fi
+    done < ${_config_tm_list}
+    rm -f ${_config_tm_list}
+
+    if [ "x${IDX_CF}" == "x2" ]; then
+        _warning "Warning! It will be used default repository url https. If you want to use ssh url, then you should delete repo https"
+        TEMPLATE=${REMOTE_NAME}-${REMOTE_TEMPLATE}
+        CONFIG_RESULT=""
+    elif [ "x${IDX_CF}" == "x1" ]; then
+        TEMPLATE=${REMOTE_NAME}-${REMOTE_TEMPLATE}
+        CONFIG_RESULT=""
+    elif [ "x${IDX_CF}" == "x0" ]; then
+        CONFIG_RESULT="ERROR"
     fi
 }
 
@@ -318,6 +388,8 @@ __chart_gen() {
 ############# End Private function #############
 
 _chart_replace() {
+    _debug_mode
+
     REPLACE_FILE=$1
     REPLACE_KEY=$2
     DEFAULT_VAL=$3

--- a/src/valve-core/_template/fetch
+++ b/src/valve-core/_template/fetch
@@ -12,6 +12,7 @@ readonly SHORT_OPT="hvon:g:s:u:"
 readonly LONG_OPT="help,verbose,overwrite,group:,service:,name:,giturl:"
 
 _help() {
+    cat $CONFIG_DIR
     cat <<EOF
 ================================================================================
 Usage: valve ${CUR_NAME} {Params}
@@ -24,8 +25,10 @@ Params:
                                                 valve fetch를 이용합니다.
                                                 ===== 템플릿 리스트 ====
 EOF
-LIST=/tmp/${THIS_NAME}-draft-ls
-sed 's/^/\t\t\t\t\t\t/' < ${LIST}
+LIST=$CONFIG_DIR/${THIS_NAME}-draft-ls
+if [ -f ${LIST} ]; then
+    sed 's/^/\t\t\t\t\t\t/' < ${LIST}
+fi
     cat <<EOF
                                                 ===== 템플릿 리스트 ====
                                                 디폴트로 fetch할 때 현재 working 디렉토리 이름을 사용합니다. valve 프로젝트에서 사용하는 서비스는 {서비스 그룹}-{서비스 이름}으로 이루어져 있습니다.
@@ -127,8 +130,8 @@ _run() {
 _fetch(){
     _result "valve-ctl version: ${THIS_VERSION}"
 
-    DIST=/tmp/${THIS_NAME}-draft-${THIS_VERSION}
-    LIST=/tmp/${THIS_NAME}-draft-ls
+    DIST=$CONFIG_DIR/${THIS_NAME}-draft-${THIS_VERSION}
+    LIST=$CONFIG_DIR/${THIS_NAME}-draft-ls
 
     NAMESPACE="${NAMESPACE:-development}"
 
@@ -148,7 +151,6 @@ _fetch(){
     __pkg_gen
     __chart_gen
 
-    _config_save
     _success 'valve fetch success'
 }
 
@@ -199,7 +201,6 @@ __pkg_version_check() {
             pushd ${DIST}
             curl -sL https://github.com/${THIS_REPO}/${THIS_NAME}/releases/download/${THIS_VERSION}/draft.tar.gz | tar xz
             popd
-
             _result "Template downloaded."
         fi
     fi
@@ -207,8 +208,7 @@ __pkg_version_check() {
 
 __pkg_name_check() {
     _debug_mode
-
-    ls ${DIST} | sort > ${LIST}     # create LIST
+    
     IDX=0
     __template_count_validate
 
@@ -260,7 +260,7 @@ __config_count_validate() {
         REMOTE_TEMPLATE=$(echo ${PARAM_NAME} | awk -F'/' '{print $2}')
     fi
     
-    _config_tm_list=/tmp/_config_tm_list
+    _config_tm_list=$CONFIG_DIR/_config_tm_list
     cat ${CONFIG} | sed '1,/REPO/d' | awk -F' ' '{print $2"|"$3}' >> ${_config_tm_list}
 
     IFS='|'

--- a/src/valve-core/repo/add
+++ b/src/valve-core/repo/add
@@ -84,15 +84,20 @@ _add() {
     if [ ${CNT} -eq 1 ]; then
         _error "There is a same repo in config file. Register another name & url"
     else
+        if [[ ${PARAMS_URL} =~ "https" ]]; then
+            TEMPLATE_NAME=$(echo $(echo ${PARAMS_URL##h*/}) | awk -F'.' '{print $1}')
+        elif [[ ${PARAMS_URL} =~ "ssh" ]]; then
+            TEMPLATE_NAME=$(echo $(echo ${PARAMS_URL##s*/}) | awk -F'.' '{print $1}')
+        fi
         if [ ${CNT_TITLE} -eq 1 ]; then
 cat <<EOF >> ${CONFIG}
-# ${PARAMS_NAME} ${PARAMS_URL}
+# ${PARAMS_NAME} ${PARAMS_URL} ${PARAMS_NAME}/${TEMPLATE_NAME}
 EOF
         cat ${CONFIG}
         else
 cat <<EOF >> ${CONFIG}
 ### REPO LIST ###
-# ${PARAMS_NAME} ${PARAMS_URL}
+# ${PARAMS_NAME} ${PARAMS_URL} ${PARAMS_NAME}/${TEMPLATE_NAME}
 EOF
         cat ${CONFIG}
         fi

--- a/src/valve-core/repo/list
+++ b/src/valve-core/repo/list
@@ -26,7 +26,11 @@ _run() {
 
 ##################################################################################
 _list() {
-    sed '1,/REPO/d' ${CONFIG} | awk -F' ' '{print "[Name] ", $2,"\t", "[Custom Template Url] ", $3}'
+    # _protocol="$(echo ${_u} | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+    # _url=$(echo ${_u} | sed -e s,$_protocol,,g)
+    # _path=$(echo ${_url} | awk -F'.' '{print $(NF-1)}' | awk -F'/' '{print $NF}')
+    echo -e "[Template]\t\t[Name]\t\t[Custom Template Url]"
+    sed '1,/REPO/d' ${CONFIG} | awk -F' ' '{print $4,"\t",$2,"\t",$3}'
 }
 ##################################################################################
 

--- a/src/valve-core/toolbox/install
+++ b/src/valve-core/toolbox/install
@@ -63,7 +63,8 @@ _run() {
         esac
         shift
     done
-
+    
+    _config_save
     if [ "${ALL}" == "true" ]; then
         _local
         _cluster


### PR DESCRIPTION
- 리스트를 /tmp 에 두지 말고 다른데 두는 방안을 생각해보자
  --> $HOME/.valve/ 에 두는 것으로 생각했습니다.

- draft를 install 시 받지 말고 리스트만 만들 수 있도록 하자
  --> draft를 valve fetch할 때만 받고 있으며, valve toolbox install 을 하면 리스트를 만들어주는 것으로 코드를 수정했습니다.

- repo add를 했을 때 master branch의 주소를 보도록 합니다.
  --> 현재 git clone은 master branch입니다.

- valve fetch할 때 해당 draft혹은 repo를 땡겨오도록 하자
  --> fetch할 때 draft를 받고 추가로 등록된 remote repository는 받도록 코드를 추가했습니다.