### PR TITLE
Command order change

### DIFF
--- a/draft/js-npm-nodejs/Dockerfile
+++ b/draft/js-npm-nodejs/Dockerfile
@@ -4,5 +4,5 @@ FROM node:10-alpine
 RUN apk add --no-cache bash curl
 EXPOSE 3000
 WORKDIR /data
-CMD ["npm", "run", "start"]
 ADD . /data
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
 - host machine에서 데이터를 복사한 후 run하도록 순서를 바꿈
   - 기존은 jenkins를 통해서만 빌드를 하던 상황이라 butler가 복사를 미리 진행하여 문제가 발생하지 않았음