### PR TITLE
Fix fetch command using default template

### DIFF
--- a/src/valve-core/_template/fetch
+++ b/src/valve-core/_template/fetch
@@ -179,16 +179,19 @@ __default_template_check() {
     _debug_mode
     if [ ! -d ${DIST}/${THIS_NAME}-draft-${THIS_VERSION} ]; then
         pushd ${DIST} > /dev/null
-        git clone https://github.com/opsnow-tools/valve-template.git ${THIS_NAME}-draft-${THIS_VERSION}
+        git clone https://github.com/opsnow-tools/valve-template.git ${THIS_NAME}-draft-${THIS_VERSION} > /dev/null
         popd > /dev/null
-        _result "Default template success"
+        _result "Default template setting success"
     else
         COUNT_DEFAULT=$(ls -al ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}/templates | awk -F' ' '{print $NF}' | sed '1,3d' | wc -l)
         if [ ${COUNT_DEFAULT} -eq 0 ]; then
             rm -rf ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
             _error "Error... You should run valve fetch one more time!!"
         else
-            _result "Default template success"
+            pushd ${DIST}/${THIS_NAME}-draft-${THIS_VERSION} > /dev/null
+            git pull > /dev/null
+            popd > /dev/null
+            _result "Default template setting success"
         fi
     fi
 }

--- a/src/valve-core/_template/fetch
+++ b/src/valve-core/_template/fetch
@@ -136,7 +136,8 @@ _fetch(){
     SERVICE_NAME=$PARAM_SERVICE
     REPOSITORY_URL=$PARAM_REPO
 
-    __pkg_version_check
+    #__pkg_version_check
+    __default_template_check
     __pkg_name_check
     __validate
 
@@ -174,35 +175,55 @@ __validate() {      # validate overwrite option
         fi
     fi
 }
-__pkg_version_check() {
+
+__default_template_check() {
     _debug_mode
-    if [ "${THIS_VERSION}" == "v0.0.0" ]; then      # Use local draft
-        rm -rf ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
-        mkdir -p ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
-
-        pushd ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
-        #LATEST_VERSION=$(curl -s https://api.github.com/repos/${THIS_REPO}/${THIS_NAME}/releases/latest | grep tag_name | cut -d'"' -f4)
-        curl -sL https://github.com/${THIS_REPO}/${THIS_NAME}/releases/download/${LATEST_VERSION}/draft.tar.gz | tar xz
-        popd
-        _result "local package used."
-    else        # Use release version
-        if [ ! -d ${DIST}/${THIS_NAME}-draft-${THIS_VERSION} ]; then   
-            echo
-            mkdir -p ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
-
-            # download
-            pushd ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
-            curl -sL https://github.com/${THIS_REPO}/${THIS_NAME}/releases/download/${THIS_VERSION}/draft.tar.gz | tar xz
-            popd
-            _result "Template downloaded."
+    if [ ! -d ${DIST}/${THIS_NAME}-draft-${THIS_VERSION} ]; then
+        pushd ${DIST} > /dev/null
+        git clone https://github.com/opsnow-tools/valve-template.git ${THIS_NAME}-draft-${THIS_VERSION}
+        popd > /dev/null
+        _result "Default template success"
+    else
+        COUNT_DEFAULT=$(ls -al ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}/templates | awk -F' ' '{print $NF}' | sed '1,3d' | wc -l)
+        if [ ${COUNT_DEFAULT} -eq 0 ]; then
+            rm -rf ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
+            _error "Error... You should run valve fetch one more time!!"
+        else
+            _result "Default template success"
         fi
     fi
 }
 
+## Deprecated
+# __pkg_version_check() {
+#     _debug_mode
+#     if [ "${THIS_VERSION}" == "v0.0.0" ]; then      # Use local draft
+#         rm -rf ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
+#         mkdir -p ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
+
+#         pushd ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
+#         #LATEST_VERSION=$(curl -s https://api.github.com/repos/${THIS_REPO}/${THIS_NAME}/releases/latest | grep tag_name | cut -d'"' -f4)
+#         curl -sL https://github.com/${THIS_REPO}/${THIS_NAME}/releases/download/${LATEST_VERSION}/draft.tar.gz | tar xz
+#         popd
+#         _result "local package used."
+#     else        # Use release version
+#         if [ ! -d ${DIST}/${THIS_NAME}-draft-${THIS_VERSION} ]; then   
+#             echo
+#             mkdir -p ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
+
+#             # download
+#             pushd ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
+#             curl -sL https://github.com/${THIS_REPO}/${THIS_NAME}/releases/download/${THIS_VERSION}/draft.tar.gz | tar xz
+#             popd
+#             _result "Template downloaded."
+#         fi
+#     fi
+# }
+
 __pkg_name_check() {
     _debug_mode
 
-    ls -d ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}/${PARAM_NAME} > /dev/null 2>&1
+    ls -d ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}/templates/${PARAM_NAME} > /dev/null 2>&1
     IDX="$?"
 
     if [ ${IDX} -eq 2 ]; then       # Check name if doesn't match.
@@ -229,14 +250,14 @@ __pkg_name_check() {
             _error "\e[4m${PARAM_NAME}\e[0m template doesn't matching anything. So use this command 'valve search' and check it out 'Templates'!"
         fi
     else        # Check name correct one.
-        PACKAGE="${THIS_NAME}-draft-${THIS_VERSION}/${PARAM_NAME}"
+        PACKAGE="${THIS_NAME}-draft-${THIS_VERSION}/templates/${PARAM_NAME}"
     fi
 }
 
 __config_count_validate() {
     _debug_mode
     INPUT_TEMPLATE_NAME=$1
-    echo $INPUT_TEMPLATE_NAME
+
     if [ -d $CONFIG_DIR/repo/custom/${INPUT_TEMPLATE_NAME} ]; then
         CONFIG_RESULT="SUCCESS"
     else
@@ -244,9 +265,9 @@ __config_count_validate() {
     fi
 }
 
+## Deprecated
 # __config_count_validate() {
 #     _debug_mode
-
 #     IDX_CF=0
 #     _is_param_name=$(echo ${PARAM_NAME} | grep '/')
 #     if [ "${_is_param_name}" == "" ]; then
@@ -256,10 +277,8 @@ __config_count_validate() {
 #         REMOTE_NAME=$(echo ${PARAM_NAME} | awk -F'/' '{print $1}')
 #         REMOTE_TEMPLATE=$(echo ${PARAM_NAME} | awk -F'/' '{print $2}')
 #     fi
-    
 #     _config_tm_list=$CONFIG_DIR/_config_tm_list
 #     cat ${CONFIG} | sed '1,/REPO/d' | awk -F' ' '{print $2"|"$3}' >> ${_config_tm_list}
-
 #     IFS='|'
 #     while read -r _name _u
 #     do
@@ -276,7 +295,6 @@ __config_count_validate() {
 #         fi
 #     done < ${_config_tm_list}
 #     rm -f ${_config_tm_list}
-
 #     if [ "x${IDX_CF}" == "x2" ]; then
 #         _warning "Warning! It will be used default repository url https. If you want to use ssh url, then you should delete repo https"
 #         TEMPLATE=${REMOTE_NAME}-${REMOTE_TEMPLATE}

--- a/src/valve-core/_template/fetch
+++ b/src/valve-core/_template/fetch
@@ -136,7 +136,6 @@ _fetch(){
     SERVICE_NAME=$PARAM_SERVICE
     REPOSITORY_URL=$PARAM_REPO
 
-    #__pkg_version_check
     __default_template_check
     __pkg_name_check
     __validate
@@ -194,32 +193,6 @@ __default_template_check() {
     fi
 }
 
-## Deprecated
-# __pkg_version_check() {
-#     _debug_mode
-#     if [ "${THIS_VERSION}" == "v0.0.0" ]; then      # Use local draft
-#         rm -rf ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
-#         mkdir -p ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
-
-#         pushd ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
-#         #LATEST_VERSION=$(curl -s https://api.github.com/repos/${THIS_REPO}/${THIS_NAME}/releases/latest | grep tag_name | cut -d'"' -f4)
-#         curl -sL https://github.com/${THIS_REPO}/${THIS_NAME}/releases/download/${LATEST_VERSION}/draft.tar.gz | tar xz
-#         popd
-#         _result "local package used."
-#     else        # Use release version
-#         if [ ! -d ${DIST}/${THIS_NAME}-draft-${THIS_VERSION} ]; then   
-#             echo
-#             mkdir -p ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
-
-#             # download
-#             pushd ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
-#             curl -sL https://github.com/${THIS_REPO}/${THIS_NAME}/releases/download/${THIS_VERSION}/draft.tar.gz | tar xz
-#             popd
-#             _result "Template downloaded."
-#         fi
-#     fi
-# }
-
 __pkg_name_check() {
     _debug_mode
 
@@ -232,19 +205,6 @@ __pkg_name_check() {
         __config_count_validate ${PARAM_NAME}
         if [ "${CONFIG_RESULT}" == "SUCCESS" ]; then
             PACKAGE="custom/${PARAM_NAME}"
-            # pushd ${DIST} > /dev/null
-            # if [ ! -d ${TEMPLATE} ]; then
-            #     echo 
-            #     _command "git clone "${TEMPLATE_URL} ${TEMPLATE}
-            #     git clone ${TEMPLATE_URL} /tmp/${TEMPLATE}
-            #     pushd /tmp/${TEMPLATE} > /dev/null
-            #     rename 's//[custom]/' *
-            #     cp -r * ${DIST}
-            #     popd
-            #     rm -rf /tmp/${TEMPLATE}
-            # fi
-            # popd
-            # PACKAGE=${TEMPLATE}
         elif [ ${CONFIG_RESULT} == "ERROR" ]; then
             rm -rf ${DIST}/${THIS_NAME}-draft-${THIS_VERSION}
             _error "\e[4m${PARAM_NAME}\e[0m template doesn't matching anything. So use this command 'valve search' and check it out 'Templates'!"
@@ -264,48 +224,6 @@ __config_count_validate() {
         CONFIG_RESULT="ERROR"
     fi
 }
-
-## Deprecated
-# __config_count_validate() {
-#     _debug_mode
-#     IDX_CF=0
-#     _is_param_name=$(echo ${PARAM_NAME} | grep '/')
-#     if [ "${_is_param_name}" == "" ]; then
-#         _error "Use valve fetch -h / valve fetch --help \n\e[4m${PARAM_NAME}\e[0m template doesn't matching anything"
-#     else
-#         ## Parsing Input remote template
-#         REMOTE_NAME=$(echo ${PARAM_NAME} | awk -F'/' '{print $1}')
-#         REMOTE_TEMPLATE=$(echo ${PARAM_NAME} | awk -F'/' '{print $2}')
-#     fi
-#     _config_tm_list=$CONFIG_DIR/_config_tm_list
-#     cat ${CONFIG} | sed '1,/REPO/d' | awk -F' ' '{print $2"|"$3}' >> ${_config_tm_list}
-#     IFS='|'
-#     while read -r _name _u
-#     do
-#         if [ "$_name" == "${REMOTE_NAME}" ]; then
-#             _protocol="$(echo ${_u} | grep :// | sed -e's,^\(.*://\).*,\1,g')"
-#             _url=$(echo ${_u} | sed -e s,$_protocol,,g)
-#             _path=$(echo ${_url} | awk -F'.' '{print $(NF-1)}' | awk -F'/' '{print $NF}')
-#             if [ "$_path" == "${REMOTE_TEMPLATE}" ]; then
-#                 if [ "${_protocol}" == "https://" ]; then
-#                     TEMPLATE_URL=$_u
-#                 fi
-#                 IDX_CF=$((IDX_CF+1))
-#             fi
-#         fi
-#     done < ${_config_tm_list}
-#     rm -f ${_config_tm_list}
-#     if [ "x${IDX_CF}" == "x2" ]; then
-#         _warning "Warning! It will be used default repository url https. If you want to use ssh url, then you should delete repo https"
-#         TEMPLATE=${REMOTE_NAME}-${REMOTE_TEMPLATE}
-#         CONFIG_RESULT=""
-#     elif [ "x${IDX_CF}" == "x1" ]; then
-#         TEMPLATE=${REMOTE_NAME}-${REMOTE_TEMPLATE}
-#         CONFIG_RESULT=""
-#     elif [ "x${IDX_CF}" == "x0" ]; then
-#         CONFIG_RESULT="ERROR"
-#     fi
-# }
 
 __pkg_variable_gen() {
     _debug_mode


### PR DESCRIPTION
- default template을 https://github.com/opsnow-tools/valve-template으로 생성했습니다.
  해당 tempalte을 git clone 하게되는데 디렉토리 명은 기존대로 valve-ctl-draft-[버전] 으로 git clone합니다.
- 이에 따라 package version을 따지던 함수를 삭제하고 default template의 유무에 따른 git clone방식의 함수를 추가했습니다. 그리고 있다면 git pull하도록 했습니다.