### PR TITLE
Hot fix valve install error / Modify LIB_DIR directory direction

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,21 +57,41 @@ fi
 # copy
 OS_NAME="$(uname | awk '{print tolower($0)}')"
 
+if [ "${OS_NAME}" == "linux" ]; then
+    if [[ ! "$PATH" =~ "${HOME}/.local/bin" ]]; then
+        echo "PATH=${HOME}/.local/bin:$PATH" >> ~/.bashrc
+        _result "Finished. Restart your shell or reload config file"
+        _result "          source ~/.bashrc # bash"
+    fi
+fi
+
+# if dev mode exists(check symbolic link)
+# LIB_DIR=$HOME/.local/share/valve
+# if [ -L ${LIB_DIR} ]; then
+#     if [ -e ${LIB_DIR} ]; then
+#         _result "check link finish"
+#         _result "Install start"
+#     else
+#         _error "broken link..."
+#     fi
+# else
+#     _result "Install start"
+# fi
+_result "Install start..."
+sleep 1
 if [ ${VERSION} == "dev" ]; then
     if [ "${OS_NAME}" == "darwin" ]; then
+        LIB_DIR=/usr/local/share/valve
         BIN_DIR=/usr/local/bin
-    elif [ "${OS_NAME}" == "linux" ]; then
-        if [[ ! "$PATH" =~ "${HOME}/.local/bin" ]]; then
-            echo "PATH=${HOME}/.local/bin:$PATH" >> ~/.bashrc
-            _result "Finished. Restart your shell or reload config file"
-            _result "          source ~/.bashrc # bash"
-        fi
+    elif [ "${OS_NAME}" == "linux" ]; then        
         BIN_DIR=$HOME/.local/bin
-        LIB_DIR=$HOME/.local/share
+        LIB_DIR=$HOME/.local/share/valve
     else
         BIN_DIR=$HOME/bin
+        LIB_DIR=$HOME/.local/share/valve
     fi
     mkdir -p ${BIN_DIR}
+    mkdir -p ${LIB_DIR}
 
     # delete old version files
     rm -rf ${LIB_DIR}
@@ -80,8 +100,8 @@ if [ ${VERSION} == "dev" ]; then
     pushd ${PWD} > /dev/null
     if [ -f src/valve.sh ]; then
         VALVE_HOME=${PWD}/src
-        ln -s ${VALVE_HOME} ${HOME}/.local/share
-        chmod -R +x ${HOME}/.local/share
+        ln -s ${VALVE_HOME} ${LIB_DIR}
+        chmod -R +x ${LIB_DIR}
         ln -s ${PWD}/src/valve.sh ${BIN_DIR}/${NAME}
     else
         _error "There is no valve-ctl home. git clone valve-ctl your fork version"
@@ -90,21 +110,21 @@ if [ ${VERSION} == "dev" ]; then
 else
     if [ "${OS_NAME}" == "darwin" ]; then
         BIN_DIR=/usr/local/bin
-        LIB_DIR=/usr/local/share
+        LIB_DIR=/usr/local/share/valve
     elif [ "${OS_NAME}" == "linux" ]; then
         BIN_DIR=$HOME/.local/bin
-        LIB_DIR=$HOME/.local/share
+        LIB_DIR=$HOME/.local/share/valve
     else
         BIN_DIR=$HOME/bin
-        LIB_DIR=$HOME/.local/share
+        LIB_DIR=$HOME/.local/share/valve
     fi
     
     # delete old version files
     rm -rf ${LIB_DIR}
     rm -f ${BIN_DIR}/${NAME}
 
-    mkdir -p ${BIN_DIR}
     mkdir -p ${LIB_DIR}
+    mkdir -p ${BIN_DIR}
 
     
 

--- a/src/common.sh
+++ b/src/common.sh
@@ -157,6 +157,6 @@ _cmd_list() {
 
     # Print commands in hidden object
     if ! find ${ROOT_CORE_DIR} -maxdepth 0 -empty | read; then
-        find ${ROOT_CORE_DIR}  | grep -e / | grep -v draft | grep -E '_' | awk -F/ '{print $7}' | grep -e '.' | grep -v '\.'
+        find ${ROOT_CORE_DIR}  | grep -E '_' | awk -F/ '{print $NF}' | grep -v '_' | grep -e '.' | grep -v '\.'
     fi
 }

--- a/src/valve.sh
+++ b/src/valve.sh
@@ -6,7 +6,7 @@ export OS_NAME="$(uname | awk '{print tolower($0)}')"
 if [ "${OS_NAME}" == "darwin" ]; then
     readonly ROOT_SHELL_DIR=$(dirname "$(readlink "$0")")
 else
-    readonly ROOT_SHELL_DIR=$HOME/.local/share
+    readonly ROOT_SHELL_DIR=$HOME/.local/share/valve
 fi
 
 export readonly ROOT_SHELL_DIR


### PR DESCRIPTION
- install시 문제가 있어 Hot fix 합니다.
- install시 MAC에서 rm permission denied가 되어 문제를 찾아보니 --> 맥에서 /usr/local/share 경로를 지우지 못하게 되어있습니다.
- 이에 symbolic link를 자유롭게 사용하기 위해 LIB_DIR을 share --> share/valve 디렉토리를 추가로 만드는 것으로 했습니다. 이에 대한 의견 부탁드립니다.

- valve -h 시 command list를 보여주는데 이를 보여주는 함수가 문제가 있어 수정했습니다.