### PR TITLE
Modify chart & common.sh

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -5,6 +5,11 @@ CONFIG=${HOME}/.valve/valve-ctl
 CONFIG_DIR=${HOME}/.valve
 LOCAL_DIR=$(echo $PWD | awk -F'/' '{print $NF}')
 
+if [ -f ${CONFIG} ]; then
+    CHARTMUSEUM=$(cat ${CONFIG} | grep CHARTMUSEUM | awk -F'=' '{print $NF}')
+    REGISTRY=$(cat ${CONFIG} | grep REGISTRY | awk -F'=' '{print $NF}')
+fi
+
 export THIS_REPO="opsnow-tools"
 export THIS_NAME="valve-ctl"
 # SHELL_DIR=${0}

--- a/src/common.sh
+++ b/src/common.sh
@@ -132,14 +132,16 @@ _select_one() {
 }
 
 _config_save() {
-    FIND_CNT=$(cat ${CONFIG} | grep REGISTRY= | wc -l | xargs)
-    if [ ${FIND_CNT} -eq 0 ]; then
-        echo "# valve config" > ${CONFIG}
-        echo "REGISTRY=${REGISTRY:-docker-registry.127.0.0.1.nip.io:30500}" >> ${CONFIG}
-        echo "CHARTMUSEUM=${CHARTMUSEUM:-chartmuseum-devops.coruscant.opsnow.com}" >> ${CONFIG}
-        echo "USERNAME=${USERNAME}" >> ${CONFIG}
-    else
-        _result "CONFIG Set"
+    if [ -f ${CONFIG} ]; then
+        FIND_CNT=$(cat ${CONFIG} | grep REGISTRY= | wc -l | xargs)
+        if [ ${FIND_CNT} -eq 0 ]; then
+            echo "# valve config" > ${CONFIG}
+            echo "REGISTRY=${REGISTRY:-docker-registry.127.0.0.1.nip.io:30500}" >> ${CONFIG}
+            echo "CHARTMUSEUM=${CHARTMUSEUM:-chartmuseum-devops.coruscant.opsnow.com}" >> ${CONFIG}
+            echo "USERNAME=${USERNAME}" >> ${CONFIG}
+        else
+            _result "CONFIG Set"
+        fi
     fi
 }
 

--- a/src/valve-core/_template/on
+++ b/src/valve-core/_template/on
@@ -187,8 +187,7 @@ _external_chart() {
     _result ${PARAM_EX}
 
     # _helm_init
-
-    __helm_repo
+    
     __find_var
     __chart_check
     __find_chart_name
@@ -419,29 +418,6 @@ __helm_delete() {
             sleep 2
         fi
     fi
-}
-
-__helm_repo() {
-    _debug_mode
-    CNT=$(helm repo list | grep chartmuseum | wc -l | xargs)
-
-    if [ "x${CNT}" == "x0" ] || [ ! -z ${FORCE} ]; then
-        # DEFAULT="${CHARTMUSEUM:-chartmuseum.opsnow.com}"
-        # _read "CHARTMUSEUM [${DEFAULT}] : "
-        # CHARTMUSEUM="${ANSWER:-$DEFAULT}"
-
-        if [ -z ${CHARTMUSEUM} ]; then
-            _error "Check config using valve config. Or use valve fetch --help / valve fetch -h and fetch your template."
-        fi
-
-        _command "helm repo add chartmuseum https://${CHARTMUSEUM}"
-        helm repo add chartmuseum https://${CHARTMUSEUM}
-
-        # _config_save
-    fi
-
-    _command "helm repo update"
-    helm repo update > /dev/null
 }
 
 __chart_check() {

--- a/src/valve-core/chart/tag
+++ b/src/valve-core/chart/tag
@@ -66,7 +66,7 @@ _run() {
         shift
     done
 
-    if [ -z ${PARAM_CHART_NAME} ]; then
+    if [ ! -z ${PARAM_CHART_NAME} ]; then
         _chart_tag
     else
         _help

--- a/src/valve-core/chart/version
+++ b/src/valve-core/chart/version
@@ -59,7 +59,7 @@ _run() {
         shift
     done
 
-    if [ -z ${PARAM_CHART_NAME} ]; then
+    if [ ! -z ${PARAM_CHART_NAME} ]; then
         _chart_version
     else
         _help

--- a/src/valve-core/toolbox/install
+++ b/src/valve-core/toolbox/install
@@ -63,7 +63,7 @@ _run() {
         esac
         shift
     done
-    
+
     _config_save
     if [ "${ALL}" == "true" ]; then
         _local
@@ -343,6 +343,7 @@ _cluster() {
 
     # namespace
     __namespace "development" true
+    __helm_repo
 }
 
 __helm_install() {
@@ -525,6 +526,27 @@ __helm_init() {
 
     __waiting_pod "${NAMESPACE}" "docker-registry"
     __waiting_pod "${NAMESPACE}" "nginx-ingress"
+}
+
+__helm_repo() {
+    _debug_mode
+    CNT=$(helm repo list | grep chartmuseum | wc -l | xargs)
+
+    if [ "x${CNT}" == "x0" ] || [ ! -z ${FORCE} ]; then
+        if [ -f ${CONFIG} ]; then
+            CHARTMUSEUM=$(cat ${CONFIG} | grep CHARTMUSEUM | awk -F'=' '{print $NF}')
+        else
+            _error "Check config using valve config. Or use valve fetch --help / valve fetch -h and fetch your template."
+        fi
+
+        _command "helm repo add chartmuseum https://${CHARTMUSEUM}"
+        helm repo add chartmuseum https://${CHARTMUSEUM}
+
+        # _config_save
+    fi
+
+    _command "helm repo update"
+    helm repo update > /dev/null
 }
 ##################################################################################
 


### PR DESCRIPTION
- Chartmuseum , Registry 변수 값이 다른 플러그인에서 오버라이드가 안되는 현상 해결
- valve chart 시 반대로 동작하는 것 수정(-z option)
- Chartmuseum 주소가 valve on시점에 등록이 되고 있어(helm repo add command) 이를 바로잡고자 valve toolbox install 시에 등록하는 것으로 변경
  --> 이는 로컬 클러스터 생성시 tiller 설치 후 자연스럽게 등록이 되어야 할 것 같아 수정