### PR TITLE
Fix valve fetch bacause of not copying .helmignore

### DIFF
--- a/src/valve-core/_template/fetch
+++ b/src/valve-core/_template/fetch
@@ -279,7 +279,7 @@ __chart_copy() {    # cp charts/acme/ to charts/${NAME}/
     _debug_mode
     if [ -d ${DIST}/${PACKAGE}/charts ]; then
         mkdir -p charts/${NAME}
-        cp -rf ${DIST}/${PACKAGE}/charts/acme/* charts/${NAME}/
+        cp -rf ${DIST}/${PACKAGE}/charts/acme/. charts/${NAME}
     fi
 }
 


### PR DESCRIPTION
Chart를 copy할 때 .helmignore가 copy되지 않아 수정합니다.