### PR TITLE
Modify valve on external chart ls not found message

### DIFF
--- a/src/valve-core/_template/on
+++ b/src/valve-core/_template/on
@@ -223,7 +223,9 @@ _external_chart() {
 __find_var() {
     _debug_mode
     # name
-    NAME="$(ls charts | head -1 | tr '/' ' ' | xargs)"
+    if [ -d "charts" ]; then
+        NAME="$(ls charts | head -1 | tr '/' ' ' | xargs)"
+    fi
 
     LIST=/tmp/${THIS_NAME}-charts-ls
 }


### PR DESCRIPTION
valve on -e
옵션으로 실행 시 chart 가 없으면 ls chart not found메시지가 뜨는 버그가 있어
이를 수정합니다.