### PR TITLE
valve update defense getopt

### DIFF
--- a/src/valve-core/_valve/update
+++ b/src/valve-core/_valve/update
@@ -27,7 +27,13 @@ EOF
 }
 
 _run() {
-
+    # getopt
+    GETOPT=$(getopt 2>&1 | head -1 | xargs)
+    if [ "${GETOPT}" == "--" ]; then
+        brew reinstall gnu-getopt
+        brew link --force gnu-getopt
+    fi
+    
     OPTIONS=$(getopt -l "${LONG_OPT}" -o "${SHORT_OPT}" -a -- "$@"  2>${CUR_DIR}/.tmp)
     if  [ $? -eq 1 ]; then
         _help


### PR DESCRIPTION
valve update 시 getopt가 없을 경우 또다시 안되는 경우가 발생하여
valve update에서도 방어 코드를 구현했습니다.