### PR TITLE
Hotfix valve command - getopt 확인

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,13 +43,6 @@ NAME="valve"
 VERSION=${1}
 _command "INPUT Version : ${VERSION}"
 
-# getopt
-GETOPT=$(getopt 2>&1 | head -1 | xargs)
-if [ "${GETOPT}" == "--" ]; then
-    brew reinstall gnu-getopt
-    brew link --force gnu-getopt
-fi
-
 if [ -z ${VERSION} ]; then
     VERSION=$(curl -s https://api.github.com/repos/${USERNAME}/${REPONAME}/releases/latest | grep tag_name | cut -d'"' -f4)
     _command "github Version : ${VERSION}"

--- a/src/common.sh
+++ b/src/common.sh
@@ -16,7 +16,7 @@ export THIS_NAME="valve-ctl"
 # SHELL_DIR=${0}
 # MYNAME=${0##*/}
 
-#OS_NAME="$(uname | awk '{print tolower($0)}')"
+OS_NAME="$(uname | awk '{print tolower($0)}')"
 
 # namespace
 NAMESPACE="${NAMESPACE:-development}"

--- a/src/valve.sh
+++ b/src/valve.sh
@@ -143,6 +143,8 @@ _set_cmd() {
 
 # main loop
 _run() {
+    _debug_mode
+
     # check first param
     if [ ! -z $1 ]; then
         CMD=$1
@@ -150,6 +152,9 @@ _run() {
         _help
         _error "No input"
     fi
+
+    # check init valve-ctl proc
+    _check_init
 
     # replace short cmd to long cmd
     _set_cmd
@@ -181,6 +186,18 @@ _run() {
 }
 
 _run $@
+
+_check_init() {
+    ### check init valve-ctl proc ###
+    # check getopt
+    GETOPT=$(getopt 2>&1 | head -1 | xargs)
+    if [ "${GETOPT}" == "--" ]; then
+        brew reinstall gnu-getopt
+        brew link --force gnu-getopt
+    fi
+
+    # 
+}
 
 _v1_help() {
 cat << EOF

--- a/src/valve.sh
+++ b/src/valve.sh
@@ -199,8 +199,6 @@ _run() {
 
 _run $@
 
-
-
 _v1_help() {
 cat << EOF
 V1: (아래 기능들은 현재 사용가능 합니다. 곧 deprecated 예정입니다.)

--- a/src/valve.sh
+++ b/src/valve.sh
@@ -141,6 +141,18 @@ _set_cmd() {
     esac
 }
 
+_check_init() {
+    ### check init valve-ctl proc ###
+    # check getopt
+    GETOPT=$(getopt 2>&1 | head -1 | xargs)
+    if [ "${GETOPT}" == "--" ]; then
+        brew reinstall gnu-getopt
+        brew link --force gnu-getopt
+    fi
+
+    # 
+}
+
 # main loop
 _run() {
     _debug_mode
@@ -187,17 +199,7 @@ _run() {
 
 _run $@
 
-_check_init() {
-    ### check init valve-ctl proc ###
-    # check getopt
-    GETOPT=$(getopt 2>&1 | head -1 | xargs)
-    if [ "${GETOPT}" == "--" ]; then
-        brew reinstall gnu-getopt
-        brew link --force gnu-getopt
-    fi
 
-    # 
-}
 
 _v1_help() {
 cat << EOF

--- a/src/valve.sh
+++ b/src/valve.sh
@@ -144,10 +144,12 @@ _set_cmd() {
 _check_init() {
     ### check init valve-ctl proc ###
     # check getopt
-    GETOPT=$(getopt 2>&1 | head -1 | xargs)
-    if [ "${GETOPT}" == "--" ]; then
-        brew reinstall gnu-getopt
-        brew link --force gnu-getopt
+    if [ "${OS_NAME}" == "darwin" ]; then
+        GETOPT=$(getopt 2>&1 | head -1 | xargs)
+        if [ "${GETOPT}" == "--" ]; then
+            brew reinstall gnu-getopt
+            brew link --force gnu-getopt
+        fi
     fi
 
     # 


### PR DESCRIPTION
- install.sh에서 getopt 를 체크하는 부분 제거
- valve.sh 에서 getopt를 체크하도록 하여 getopt가 만약 설치되지 않더라도 어떠한 valve command 가 동작할 경우 확인해서 설치하도록 함.